### PR TITLE
remove creation date

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,6 @@ plugins:
   - search
   - git-revision-date-localized:
       type: datetime
-      enable_creation_date: true
 
 markdown_extensions:
   - pymdownx.betterem:


### PR DESCRIPTION
Seems to be the same as the last updated, always. So remove for cleanliness and prevent confusion.